### PR TITLE
RDKEMW-2692: secauthn - Remove workaround fixes on Middleware

### DIFF
--- a/recipes-bringup/workaround/secauthn/secauthn_git.bbappend
+++ b/recipes-bringup/workaround/secauthn/secauthn_git.bbappend
@@ -1,2 +1,0 @@
-PV:pn-secauthn = "2.4.2"
-SRCREV:pn-secauthn = "737bcba35f900e1012702337005c8ad78daf590a"


### PR DESCRIPTION
Reason for change: Revision is updated to the overrided revision on upgrade of meta layer
Test Procedure: None
Risks: Low
Priority: P1
Signed-off-by: snazee925@cable.comcast.com