### PR TITLE
RDKEMW-2533: image assembler tv us migration support

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -146,6 +146,7 @@ RDEPENDS:${PN} = " \
     lzo \
     mtd-utils-ubifs \
     mpg123 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', " pulseaudio ", "", d)} \
     mtdev \
     smcroute \
     speex \


### PR DESCRIPTION
Reason for change:
	 image assembler tv us migration support
	 Missing package pulse audio added to middleware package dependencies
Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>