### PR TITLE
RDKOSS-203: Move gdb to middleware

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -286,6 +286,8 @@ PACKAGE_ARCH:pn-dropbear = "${MIDDLEWARE_ARCH}"
 
 PACKAGE_ARCH:pn-mpg123 = "${MIDDLEWARE_ARCH}"
 
+PACKAGE_ARCH:pn-gdb = "${MIDDLEWARE_ARCH}"
+
 PR:pn-libwpe = "r0"
 PACKAGE_ARCH:pn-libwpe = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for the change: The gdb is removed from oss as it is a gplv3 licensed. configured middleware arch to gdb as middleware packagegroup still depends on it