### PR TITLE
RDKEMW-2910 : Packagegroup for middleware layer - cleanup workaround

### DIFF
--- a/recipes-bringup/packagegroups/packagegroup-middleware-layer.bbappend
+++ b/recipes-bringup/packagegroups/packagegroup-middleware-layer.bbappend
@@ -7,12 +7,8 @@ RDEPENDS:${PN}:remove += " \
     airplay-daemon \
     netflix \
     \
-    libloader-app \
-    cobaltwidget \
-    starboard-nplb-widget \
-    \
     ctrlm-irdb-uei \
     "
 
-DEPENDS:remove += " sky-nrdplugin airplay-application airplay-daemon cobaltwidget"
+DEPENDS:remove += " sky-nrdplugin airplay-application airplay-daemon "
 


### PR DESCRIPTION
Reason for change : Cleanup workaround fixes in mw
Test Procedure       :  remove component from RDEPENDS in package group and verify compilation.
Priority                   : P1
Risks                      : None
Signed-off-by        : daya_christudasan@comcast.com

