### PR TITLE
RDKEMW-2941 : Release 1.0.0 for RDKNativeScript components from rdkce…

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -26,8 +26,8 @@ PV:pn-rtcore = "1.0.1"
 PR:pn-rtcore = "r2"
 PACKAGE_ARCH:pn-rtcore = "${MIDDLEWARE_ARCH}"
 
-PV:pn-rdknativescript = "1.0.1"
-PR:pn-rdknativescript = "r3"
+PV:pn-rdknativescript = "1.0.0"
+PR:pn-rdknativescript = "r0"
 PACKAGE_ARCH:pn-rdknativescript = "${MIDDLEWARE_ARCH}"
 
 PV:pn-rmfosal = "1.0.0"


### PR DESCRIPTION
…ntral

Reason for change: Updating the release tag in meta layers.
Test Procedure: build and playback should be successful.
Risks: low
Priority: P2