### PR TITLE
RDKEMW-2963: entservices-mediaanddrm - Remove workaround fixes on middleware

### DIFF
--- a/recipes-bringup/workaround/rdkservices/entservices-mediaanddrm.bbappend
+++ b/recipes-bringup/workaround/rdkservices/entservices-mediaanddrm.bbappend
@@ -1,3 +1,0 @@
-do_install:append() {
-    sed -i '/"precondition":\[/,/\],/d' ${D}/etc/WPEFramework/plugins/OCDM.json
-}


### PR DESCRIPTION
Reason for change: Removed the file entservices-mediaanddrm.bbappend
Test Procedure: None
Risks: Low
Priority: P1
Signed-off-by: nejumathoppil_nazar@comcast.com