### PR TITLE
RDKEMW-2915: Remove workaround for qtbase

### DIFF
--- a/recipes-bringup/workaround/qtbase/qtbase_git.bbappend
+++ b/recipes-bringup/workaround/qtbase/qtbase_git.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS:${PN}:remove += "openssl-1.1.1l"


### PR DESCRIPTION
Reason for change: Remove workaround for qtbase
Test Procedure: None
Risks: Low
Priority: P1
Signed-off-by:mkooda197@cable.comcast.com