### PR TITLE
RDKEMW-2972 : Packagegroup - ctrlm-irdb-uei for mw layer - cleanup workaround

### DIFF
--- a/recipes-bringup/packagegroups/packagegroup-middleware-layer.bbappend
+++ b/recipes-bringup/packagegroups/packagegroup-middleware-layer.bbappend
@@ -6,8 +6,6 @@ RDEPENDS:${PN}:remove += " \
     airplay-application \
     airplay-daemon \
     netflix \
-    \
-    ctrlm-irdb-uei \
     "
 
 DEPENDS:remove += " sky-nrdplugin airplay-application airplay-daemon "


### PR DESCRIPTION
Reason for change : workaround cleanup
Test Procedure       : Remove component from package group and verify.
Priority                   : P1
Risks                      : None
Signed-off-by        : daya_christudasan@comcast.com