### PR TITLE
RDKEMW-1009 Add COM-RPC support to DeviceDiagnostics plugin (#108)

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -137,7 +137,7 @@ PV:pn-entservices-connectivity = "1.0.1"
 PR:pn-entservices-connectivity = "r0"
 PACKAGE_ARCH:pn-entservices-connectivity = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-deviceanddisplay = "1.0.9"
+PV:pn-entservices-deviceanddisplay = "1.1.1"
 PR:pn-entservices-deviceanddisplay = "r0"
 PACKAGE_ARCH:pn-entservices-deviceanddisplay = "${MIDDLEWARE_ARCH}"
 
@@ -242,7 +242,7 @@ PACKAGE_ARCH:pn-libflac = "${MIDDLEWARE_ARCH}"
 
 PACKAGE_ARCH:pn-wpeframework = "${MIDDLEWARE_ARCH}"
 
-PV:pn-rdkservices-apis = "1.3.1"
+PV:pn-rdkservices-apis = "1.3.2"
 PR:pn-rdkservices-apis = "r0"
 PACKAGE_ARCH:pn-rdkservices-apis = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
* RDKEMW-1009 Add COM-RPC support to DeviceDiagnostics plugin

Reason for change: Add COM-RPC support for DeviceDiagnostics Test Procedure: Test DeviceDiagnostics - All APIs
Risks: Medium
Priority: P1
Signed-off-by:Dineshkumar P dinesh_kumar2@comcast.com

* RDKEMW-1009 Add COM-RPC support to DeviceDiagnostics plugin