### PR TITLE
RDKEMW-2572 [RDKE] DeviceInfo.make coming as element for Sharp

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -137,7 +137,7 @@ PV:pn-entservices-connectivity = "1.0.1"
 PR:pn-entservices-connectivity = "r0"
 PACKAGE_ARCH:pn-entservices-connectivity = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-deviceanddisplay = "1.1.6"
+PV:pn-entservices-deviceanddisplay = "1.1.7"
 PR:pn-entservices-deviceanddisplay = "r0"
 PACKAGE_ARCH:pn-entservices-deviceanddisplay = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: read make from MFR first and if not available fall back to device.properties.
Test Procedure: None
Risks: None
Signed-off-by: ramkumar_prabaharan <ramkumar_prabaharan@comcast.com>