### PR TITLE
Revert "RDK7RM-50: Updating to tag 0.12.2 from support/rdk7-main"

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -293,7 +293,7 @@ PV:pn-memcr = "1.0.2"
 PR:pn-memcr = "r0"
 PACKAGE_ARCH:pn-memcr = "${MIDDLEWARE_ARCH}"
 
-PV:pn-networkmanager-plugin = "0.12.2"
+PV:pn-networkmanager-plugin = "0.12.1"
 PR:pn-networkmanager-plugin = "r0"
 PACKAGE_ARCH:pn-networkmanager-plugin = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
This reverts commit d60c997a9e88c03f4785834b59d5c7e077312f27.