### PR TITLE
RDKEMW-4903: Optimize AppArmor Profile Load

### DIFF
--- a/conf/include/generic-srcrev.inc
+++ b/conf/include/generic-srcrev.inc
@@ -1,4 +1,4 @@
-SRCREV_rdk-apparmor-profiles = "6b493ce3338e64e8a66224942d6af84b440d52c9"
+SRCREV_rdk-apparmor-profiles = "9533945f044bc93ebfa045e2d235dab0fb06d6a2"
 SRCREV_rdk-libunpriv = "2ab2a9e1f15e132e96fbb33d3fb45061b512aa8c"
 SRCREV:pn-rdkat = "e52ebe05b6703dff7ca700fd286d84c0c72c41ea"
 SRCREV:pn-ctrlm-main = "5bdb9ed9c181126cd83f422a0daa088df671b691"


### PR DESCRIPTION
Optimize the apparmor_parser.sh script for loading the Apparmor profiles.

Reason for change: Loading Apparmor profiles efficiently during boot-up.
Test Procedure: Ensure profiles are loading in expected mode.
Risks: low

Signed-off-by: ldonth501 <LasyaPrakarsha_DonthiVenkata@comcast.com>