### PR TITLE
RDKEMW-3216 : Resiliency improvements for Persistent Store (#6244)

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -140,7 +140,7 @@ PV:pn-entservices-deviceanddisplay = "2.0.1"
 PR:pn-entservices-deviceanddisplay = "r0"
 PACKAGE_ARCH:pn-entservices-deviceanddisplay = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-infra = "1.4.0"
+PV:pn-entservices-infra = "1.4.2"
 PR:pn-entservices-infra = "r0"
 PACKAGE_ARCH:pn-entservices-infra = "${MIDDLEWARE_ARCH}"
 

--- a/conf/include/generic-srcrev.inc
+++ b/conf/include/generic-srcrev.inc
@@ -72,4 +72,4 @@ SRCREV:pn-dvbsubdecoder= "${SRCREV:pn-subttxrend-app}"
 SRCREV:pn-ttxdecoder = "${SRCREV:pn-subttxrend-app}"
 SRCREV:pn-rdkcertconfig = "9bc36349fcb52101387fcc0adc1f20b14d8b5114"
 SRCREV:pn-packager-lisa = "339c8f08048448e732e8e7a4ff0644712da77600"
-
+SRCREV:pn-entservices-infra = "05504506ef95f360f55912ba04f55824ba3f78d6"


### PR DESCRIPTION
Reason for change: Create or use backup on start.
Test Procedure: Corrupt store and reboot.
Risks: None


RDKEMW-4795 : Account the case when ASSERT is no-op (#6256)

Reason for change: Code in ASSERT seemingly did not run
Test Procedure: Corrupt store is removed
Risks: None