### PR TITLE
RDKEMW-4788: [meta-middleware-generic-support ] (TEST) use HDMI Input plugin RDKV and AVInput RDKE

### DIFF
--- a/conf/include/generic-srcrev.inc
+++ b/conf/include/generic-srcrev.inc
@@ -1,7 +1,7 @@
 SRCREV_rdk-apparmor-profiles = "6b493ce3338e64e8a66224942d6af84b440d52c9"
 SRCREV_rdk-libunpriv = "2ab2a9e1f15e132e96fbb33d3fb45061b512aa8c"
 SRCREV:pn-rdkat = "e52ebe05b6703dff7ca700fd286d84c0c72c41ea"
-SRCREV:pn-ctrlm-main = "99d9e3bda6e59542970eadcdcaaa825d6d5875e8"
+SRCREV:pn-ctrlm-main = "9fa845929889723bbf7be9fd5bd7fff4cda1fb53"
 SRCREV:pn-ctrlm-headers = "${SRCREV:pn-ctrlm-main}"
 SRCREV:pn-xr-voice-sdk = "b628e1ac2b8b149e87de650ca87d6b78969521c4"
 SRCREV:pn-xr-voice-sdk-headers = "${SRCREV:pn-xr-voice-sdk}"


### PR DESCRIPTION
Reason for change:
Test Procedure:
Risks:              Low