### PR TITLE
RDKEMW-1021: Add COM-RPC support to SharedStorage plugin

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -241,7 +241,7 @@ PACKAGE_ARCH:pn-libflac = "${MIDDLEWARE_ARCH}"
 
 PACKAGE_ARCH:pn-wpeframework = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-apis = "1.7.0"
+PV:pn-entservices-apis = "1.7.1"
 PR:pn-entservices-apis = "r0"
 PACKAGE_ARCH:pn-entservices-apis = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for Change: Added COM-RPC support to SharedStorage plugin 
Test Procedure: Test- All SharedStorage plugin APIs Risks: Low
Priority: P1
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]