### PR TITLE
RDKEMW-2565 Add deviceIdentification plugin details into deviceinfo

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -136,7 +136,7 @@ PV:pn-entservices-connectivity = "1.0.1"
 PR:pn-entservices-connectivity = "r0"
 PACKAGE_ARCH:pn-entservices-connectivity = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-deviceanddisplay = "3.0.2"
+PV:pn-entservices-deviceanddisplay = "3.0.3"
 PR:pn-entservices-deviceanddisplay = "r0"
 PACKAGE_ARCH:pn-entservices-deviceanddisplay = "${MIDDLEWARE_ARCH}"
 
@@ -241,7 +241,7 @@ PACKAGE_ARCH:pn-libflac = "${MIDDLEWARE_ARCH}"
 
 PACKAGE_ARCH:pn-wpeframework = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-apis = "1.7.1"
+PV:pn-entservices-apis = "1.7.2"
 PR:pn-entservices-apis = "r0"
 PACKAGE_ARCH:pn-entservices-apis = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Add chipset and ReleaseVersion property to DeviceInfo Plugin
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com