### PR TITLE
RDKEMW-5355 - Remove Bind/Named from RDKE stack

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -98,8 +98,6 @@ RDEPENDS:${PN} = " \
     xr-voice-sdk \
     bluez5 \
     bind \
-    bind-dl \
-    bind-named \
     lcms \
     libunwind \
     wayland \


### PR DESCRIPTION
Reason for change: Remove Bind/Named from RDKE stack
Test Procedure: Basic sanity
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)