### PR TITLE
RDKEMW-5799 - [RDKE] [RTK-VA-DEVICES] Audio is not heard through the bluetooth speaker. 

### DIFF
--- a/conf/include/generic-srcrev.inc
+++ b/conf/include/generic-srcrev.inc
@@ -1,5 +1,5 @@
 SRCREV_rdk-apparmor-profiles = "6b493ce3338e64e8a66224942d6af84b440d52c9"
-SRCREV_rdk-libunpriv = "2ab2a9e1f15e132e96fbb33d3fb45061b512aa8c"
+SRCREV_rdk-libunpriv = "d8d4b7a953e7afc14751d1e0a9614ba20c6c410b"
 SRCREV:pn-rdkat = "e52ebe05b6703dff7ca700fd286d84c0c72c41ea"
 SRCREV:pn-ctrlm-main = "577fc2b835930b9698bcc17bf554424858ce4275"
 SRCREV:pn-ctrlm-headers = "${SRCREV:pn-ctrlm-main}"


### PR DESCRIPTION
Reason for change: libunpriv component SHA update on metalayer to run the CI verification.

Test Procedure: Verified the bluetooth audio in RTK VA platform.

Signed-off-by: thenmozhi_kathiravan@comcast.com