### PR TITLE
RDKEMW-6063 - NetworkManager Plugin Release - 0.22.0

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -284,7 +284,7 @@ PV:pn-memcr = "1.0.2"
 PR:pn-memcr = "r0"
 PACKAGE_ARCH:pn-memcr = "${MIDDLEWARE_ARCH}"
 
-PV:pn-networkmanager-plugin = "0.21.0"
+PV:pn-networkmanager-plugin = "0.22.0"
 PR:pn-networkmanager-plugin = "r0"
 PACKAGE_ARCH:pn-networkmanager-plugin = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Upgrade to new release - 0.22.0 with following Bug fixes
- Fixed trigger point for the connectivity monitoring
- Posting onWiFiStateChange Event when link-up for wifi event is received.