### PR TITLE
RDKEMW-4406 - Device failed to detect USB

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -140,7 +140,7 @@ PV:pn-entservices-deviceanddisplay = "3.0.4"
 PR:pn-entservices-deviceanddisplay = "r0"
 PACKAGE_ARCH:pn-entservices-deviceanddisplay = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-infra = "1.4.4.1"
+PV:pn-entservices-infra = "1.4.4.2"
 PR:pn-entservices-infra = "r0"
 PACKAGE_ARCH:pn-entservices-infra = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for Change: Fix Auto mount issue with usb device
Test Procedure: Check for usb mount scenarios
Risks: Low
Priority: P1