### PR TITLE
RDKEMW-5867 - Integrate the ODM Phase 2

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -144,7 +144,7 @@ PV:pn-entservices-infra = "1.4.4.2"
 PR:pn-entservices-infra = "r0"
 PACKAGE_ARCH:pn-entservices-infra = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-inputoutput = "1.1.1"
+PV:pn-entservices-inputoutput = "1.1.1.1"
 PR:pn-entservices-inputoutput = "r0"
 PACKAGE_ARCH:pn-entservices-inputoutput = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for Change: Integrate the ODM Phase 2 to middleware
Test Procedure: Check AVOuput plugin APIs
Risks: Low
Priority: P1