### PR TITLE
RDKEMW-6189,RDKEMW-6300,RDKEMW-6097,RDKEMW-5763,RDKEMW-5756 - NetworkManager Plugin Release - 0.23.0

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -284,7 +284,7 @@ PV:pn-memcr = "1.0.2"
 PR:pn-memcr = "r0"
 PACKAGE_ARCH:pn-memcr = "${MIDDLEWARE_ARCH}"
 
-PV:pn-networkmanager-plugin = "0.22.0"
+PV:pn-networkmanager-plugin = "0.23.0"
 PR:pn-networkmanager-plugin = "r0"
 PACKAGE_ARCH:pn-networkmanager-plugin = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Upgrade to new release - 0.23.0 with following Bug fixes
- Added L1/L2 workflow for LegacyNetwork, LegacyWiFi and NetworkManager Plugins
- Fixed RemoveKnownSSID method to handle the invalid inputs
- Fixed the logging in GetIPSettings