### PR TITLE
RDKEMW-6402: [AI2.0][LM] Incorrect Return Type Handling in getRuntime

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -136,7 +136,7 @@ PV:pn-entservices-deviceanddisplay = "3.1.2"
 PR:pn-entservices-deviceanddisplay = "r0"
 PACKAGE_ARCH:pn-entservices-deviceanddisplay = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-infra = "1.7.0"
+PV:pn-entservices-infra = "1.7.1"
 PR:pn-entservices-infra = "r0"
 PACKAGE_ARCH:pn-entservices-infra = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change : Fixed the return type of getRuntimeStats()
Test Procedure: Run AppManager L1 test in github workflow and test in full stack
Risks: Medium
Priority: P1
Signed-off-by: Siva Thandayuthapani [sithanda@synamedia.com](mailto:sithanda@synamedia.com)