### PR TITLE
RDKEMW-6544:Add ExecStop to all the Thunder-Startup-Services & Send Deactivate curl request

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -169,6 +169,7 @@ RDEPENDS:${PN} = " \
     os-release \
     wlan-p2p \
     thunderhangrecovery \
+    plugindeactivator \
     "
 
 DEPENDS += " cjson crun jsonrpc libarchive libdash libevent gssdp harfbuzz hiredis \


### PR DESCRIPTION
Reason for change: Added plugindeactivator recipes to the depends list of packagegroup-middleware-layer.bb
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1