### PR TITLE
RDKEMW-6566: Bump entservices-apis to 1.15.0

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -233,7 +233,7 @@ PACKAGE_ARCH:pn-libflac = "${MIDDLEWARE_ARCH}"
 
 PACKAGE_ARCH:pn-wpeframework = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-apis = "1.14.2"
+PV:pn-entservices-apis = "1.15.0"
 PR:pn-entservices-apis = "r0"
 PACKAGE_ARCH:pn-entservices-apis = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Change-Id: I0e599ef5c70337ca155c1731c5a4d7ccdc1037cf