### PR TITLE
RDKEMW-6541:Pull the PluginActivator from Federated Repo

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -169,6 +169,7 @@ RDEPENDS:${PN} = " \
     os-release \
     wlan-p2p \
     thunderhangrecovery \
+    thunderpluginactivator \
     "
 
 DEPENDS += " cjson crun jsonrpc libarchive libdash libevent gssdp harfbuzz hiredis \


### PR DESCRIPTION
Reason for change: Added PluginActivator recipes to packagegroup middleware layer
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1