### PR TITLE
RDKEMW-6225 NetworkManager Plugin Release - 0.25.0

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -285,7 +285,7 @@ PV:pn-memcr = "1.0.2"
 PR:pn-memcr = "r0"
 PACKAGE_ARCH:pn-memcr = "${MIDDLEWARE_ARCH}"
 
-PV:pn-networkmanager-plugin = "0.23.0"
+PV:pn-networkmanager-plugin = "0.25.0"
 PR:pn-networkmanager-plugin = "r0"
 PACKAGE_ARCH:pn-networkmanager-plugin = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Upgrade to new release - 0.25.0 with following Bug fixes

- Implemented SetHostname method which can send device's hostname over DHCP explicitly
- Implemented L1/L2 for netsrvmgr (RDK), libnm backends
- Clamped the WIFI Noise value to be within 0 dBm to -96 dBm
- Handled Plugin Termination sequence to stop the monitoring thread before exit
- Handled out-of-process plugin configuration as string
- Fixed Router Discovery to handle dual interface
- Fixed Internet Connectivity Monitoring to not to poll unless requested
- Addressed coverity reported issue