### PR TITLE
RDKEMW-6541:Pull the PluginActivator from Federated Repo (#1345)

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -289,9 +289,9 @@ PV:pn-networkmanager-plugin = "1.0.0"
 PR:pn-networkmanager-plugin = "r0"
 PACKAGE_ARCH:pn-networkmanager-plugin = "${MIDDLEWARE_ARCH}"
 
-PV:pn-thunderhangrecovery = "1.0.0"
-PR:pn-thunderhangrecovery = "r0"
-PACKAGE_ARCH:pn-thunderhangrecovery = "${MIDDLEWARE_ARCH}"
+PV:pn-thunder-hang-recovery = "1.0.0"
+PR:pn-thunder-hang-recovery = "r0"
+PACKAGE_ARCH:pn-thunder-hang-recovery = "${MIDDLEWARE_ARCH}"
 
 PV:pn-wpeframework-ui = "1.0.0"
 PR:pn-wpeframework-ui = "r0"

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -168,7 +168,8 @@ RDEPENDS:${PN} = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'rdkwindowmanager', " rdkwindowmanager ", "", d)} \
     os-release \
     wlan-p2p \
-    thunderhangrecovery \
+    thunder-hang-recovery \
+    thunder-plugin-activator \
     "
 
 DEPENDS += " cjson crun jsonrpc libarchive libdash libevent gssdp harfbuzz hiredis \


### PR DESCRIPTION
* RDKEMW-6541:Pull the PluginActivator from Federated Repo

Reason for change: Added PluginActivator recipes to packagegroup middleware layer
Test Procedure: please referred ticket descriptions
Risks: Medium
Priority: P1

* renamed the receipes name

* Update packagegroup-middleware-layer.bb

* rename Thunderhangrecovery recipes