### PR TITLE
RDKEMW-6934: [RDKEMW-6935] [RDKEMW-6785] [RDKE][Rack][Element/Sky]: W…

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -140,7 +140,7 @@ PV:pn-entservices-deviceanddisplay = "3.0.4.1"
 PR:pn-entservices-deviceanddisplay = "r0"
 PACKAGE_ARCH:pn-entservices-deviceanddisplay = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-infra = "1.4.4.3"
+PV:pn-entservices-infra = "1.4.4.4"
 PR:pn-entservices-infra = "r0"
 PACKAGE_ARCH:pn-entservices-infra = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
…PEFramework crash.

Reason for change:
WPEFramework crashwith signature WPEFramework::Plugin::USBDeviceImplementation::libUSBEventsHandlingThread with fingerprint 14820164 during Reboot testing. [RDKMW][RTK-XIONE] WPEFramework crash Observed while Launching and Playing XUMO Play.

Test Procedure:
Reboot testing needs to do. No. of Reboots: Atleast 50 Reboots. Refer RDKEMW-6934, RDKEMW-6935, RDKEMW-6785 Risks: High
Priority: P1