### PR TITLE
RDKEMW-8302 - NetworkManager Plugin Release - 1.3.0

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -284,7 +284,7 @@ PV:pn-memcr = "1.0.2"
 PR:pn-memcr = "r0"
 PACKAGE_ARCH:pn-memcr = "${MIDDLEWARE_ARCH}"
 
-PV:pn-networkmanager-plugin = "1.0.0"
+PV:pn-networkmanager-plugin = "1.3.0"
 PR:pn-networkmanager-plugin = "r0"
 PACKAGE_ARCH:pn-networkmanager-plugin = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Upgrade to new release - 1.3.0 with following Bug fixes

Implemented NetworkManagerProxy library which can help Thunder to Create COM-RPC connection to Out-Of-Process plugin
Implemented Internet Connectivity Monitoring for specific to Primary Interface.
Updated to not to post onInternetStatusChanged event when secondary interface is disturbed.