### PR TITLE
RDKEMW-8319 : Unwanted Logs are Printed in TTS plugin

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -148,7 +148,7 @@ PV:pn-entservices-inputoutput = "1.1.1.3"
 PR:pn-entservices-inputoutput = "r0"
 PACKAGE_ARCH:pn-entservices-inputoutput = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-mediaanddrm = "1.1.2.1"
+PV:pn-entservices-mediaanddrm = "1.1.2.4"
 PR:pn-entservices-mediaanddrm = "r0"
 PACKAGE_ARCH:pn-entservices-mediaanddrm = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
 Reason for change: disabled log containing text

Test Procedure: Same as ticket
Priority: P1
Risks: None