### PR TITLE
RDKEMW-9572: Update entservices-casting PV to v1.2.12

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -128,7 +128,7 @@ PV:pn-librsvg = "2.40.21"
 PR:pn-librsvg = "r0"
 PACKAGE_ARCH:pn-librsvg = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-casting = "1.2.8"
+PV:pn-entservices-casting = "1.2.12"
 PR:pn-entservices-casting = "r0"
 PACKAGE_ARCH:pn-entservices-casting = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
RDKEMW-9572: Update entservices-casting PV to v1.2.12
Reason for Change: Fix for Miracast Service crash while reactivating the service