### PR TITLE
RDKEMW-8289 : CEC is not working after an FSR

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -144,7 +144,7 @@ PV:pn-entservices-infra = "3.1.0"
 PR:pn-entservices-infra = "r0"
 PACKAGE_ARCH:pn-entservices-infra = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-inputoutput = "1.4.11"
+PV:pn-entservices-inputoutput = "1.5.1"
 PR:pn-entservices-inputoutput = "r0"
 PACKAGE_ARCH:pn-entservices-inputoutput = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
RDKEMW-8289 : CEC is not working after an FSR

Reason for change: Added new function such that on de-init we will not persist the disabled CEC status Test Procedure:
Risks: low
Priority: P1

Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>