### PR TITLE
RDKEMW-9254 : NetworkManager Plugin Release - 1.6.0

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -286,7 +286,7 @@ PV:pn-memcr = "1.0.2"
 PR:pn-memcr = "r0"
 PACKAGE_ARCH:pn-memcr = "${MIDDLEWARE_ARCH}"
 
-PV:pn-networkmanager-plugin = "1.4.0"
+PV:pn-networkmanager-plugin = "1.6.0"
 PR:pn-networkmanager-plugin = "r0"
 PACKAGE_ARCH:pn-networkmanager-plugin = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Upgrade to new release - 1.6.0 with following Bug fixes
- Integrated MfrMgr to persist WiFi Credential for DRI & Rollback to RDK-V Backend
- Implemented proper shutdown sequence for NetworkManager Plugin.
- Updated GDbus Support with all the latest fixes that went thro libnm backend