### PR TITLE
RDKEMW-10660: Adding T1 logging for ap_info_split details

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -286,7 +286,7 @@ PV:pn-memcr = "1.0.2"
 PR:pn-memcr = "r0"
 PACKAGE_ARCH:pn-memcr = "${MIDDLEWARE_ARCH}"
 
-PV:pn-networkmanager-plugin = "1.8.0"
+PV:pn-networkmanager-plugin = "1.9.0"
 PR:pn-networkmanager-plugin = "r0"
 PACKAGE_ARCH:pn-networkmanager-plugin = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
RDKEMW-10660: Adding T1 logging for ap_info_split details

Reason for change: Added temporary log line for T1 to get ap_info details
Test Procedure: grep the "bssid=" in wpeframework.log
Priority:P1
Risks: Medium