### PR TITLE
RDKEMW-11896: Integrate entservices-firmwareupdate to middleware builds 

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -70,8 +70,8 @@ RDEPENDS:${PN} = " \
     entservices-peripherals \
     entservices-runtime \
     entservices-softwareupdate \
-    entservices-firmwareupdate \
     entservices-firmwaredownload \
+    entservices-firmwareupdate \
     entservices-mediaanddrm-screencapture \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \


### PR DESCRIPTION
Reason For Change: Integrate entservices-firmwareupdate to middleware builds
Test procedure : Compiled and Verified
version: minor
Priority: P1