### PR TITLE
RDKEMW-12941: Integrating framerate repo to middleware

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -72,6 +72,7 @@ RDEPENDS:${PN} = " \
     entservices-softwareupdate \
     entservices-firmwaredownload \
     entservices-firmwareupdate \
+    entservices-framerate \
     entservices-mediaanddrm-screencapture \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \


### PR DESCRIPTION
Reason For Change: Integrate entservices-framerate to middleware builds
Test procedure : Compiled and Verified
version: patch
Priority: P1