### PR TITLE
RDKEMW-12942: Integrate system mode repo to MW builds 

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -72,6 +72,7 @@ RDEPENDS:${PN} = " \
     entservices-softwareupdate \
     entservices-firmwaredownload \
     entservices-firmwareupdate \
+    entservices-systemmode \
     entservices-mediaanddrm-screencapture \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \


### PR DESCRIPTION
Reason For Change: Integrate entservices-systemmode to middleware builds
Test procedure : Compiled and Verified
version: patch
Priority: P1