### PR TITLE
RDKEMW-13048: [8.4] AMC+ app not persisting Login credentials after EntOS Migration

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -171,6 +171,7 @@ RDEPENDS:${PN} = " \
     wlan-p2p \
     thunder-hang-recovery \
     thunder-plugin-activator \
+    sqlite3 \
     ${@bb.utils.contains('DISTRO_FEATURES', 'sceneset', " sceneset ", "", d)} \
     "
 
@@ -179,5 +180,5 @@ DEPENDS += " cjson crun jsonrpc libarchive libdash libevent gssdp harfbuzz hired
              libpcre libseccomp  libsoup-2.4 trower-base64 libxkbcommon \
              log4c mbedtls rdkperf cjwt nghttp2 ucresolv fcgi glib-openssl libol \
              graphite2 curl openssl zlib glib-networking glib-2.0 \
-             lighttpd systemd \
+             lighttpd systemd sqlite3 \
              "


### PR DESCRIPTION
Reason for change: login is not persisting in ENTOS for AMC+ in WNC Rogers
Test Procedure: None
Priority: P1
Risks: Medium