### PR TITLE
RDKEMW-12964: Firebolt C++ API

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -6,11 +6,11 @@ PV:pn-qtwayland = "5.15.7"
 PR:pn-qtwayland = "r1"
 PACKAGE_ARCH:pn-qtwayland = "${MIDDLEWARE_ARCH}"
 
-PV:pn-firebolt-cpp-transport = "0.2.0"
+PV:pn-firebolt-cpp-transport = "1.0.0"
 PR:pn-firebolt-cpp-transport = "r0"
 PACKAGE_ARCH:pn-firebolt-cpp-transport = "${MIDDLEWARE_ARCH}"
 
-PV:pn-firebolt-cpp-client = "0.2.0"
+PV:pn-firebolt-cpp-client = "0.2.2"
 PR:pn-firebolt-cpp-client = "r0"
 PACKAGE_ARCH:pn-firebolt-cpp-client = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
RDKEMW-12964 : Firebolt C++ API

Reason for change: Update versions of the Firebolt C++ Client and the
transport layer shared among other Clients. Make recipes more generic.

Test Procedure: Build the image

Risks: None