### PR TITLE
RDKEMW-12964: Move PV, PR, PACKAGE_ARCH to individual recipes

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -6,14 +6,6 @@ PV:pn-qtwayland = "5.15.7"
 PR:pn-qtwayland = "r1"
 PACKAGE_ARCH:pn-qtwayland = "${MIDDLEWARE_ARCH}"
 
-PV:pn-firebolt-cpp-transport = "1.0.0"
-PR:pn-firebolt-cpp-transport = "r0"
-PACKAGE_ARCH:pn-firebolt-cpp-transport = "${MIDDLEWARE_ARCH}"
-
-PV:pn-firebolt-cpp-client = "0.2.2"
-PR:pn-firebolt-cpp-client = "r0"
-PACKAGE_ARCH:pn-firebolt-cpp-client = "${MIDDLEWARE_ARCH}"
-
 PV:pn-firebolt-ripple = "${RIPPLE_RELEASE_VER}"
 PR:pn-firebolt-ripple = "r1"
 PACKAGE_ARCH:pn-firebolt-ripple = "${MIDDLEWARE_ARCH}"


### PR DESCRIPTION
RDKEMW-12964 : Move PV, PR, PACKAGE_ARCH to individual recipes
Reason for change: Move PV, PR closer to recipes

Test Procedure: Build the image

Risks: None