### PR TITLE
RDKEMW-13094 : Integrate entservices-userpreferences to middleware builds

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -72,6 +72,7 @@ RDEPENDS:${PN} = " \
     entservices-softwareupdate \
     entservices-firmwaredownload \
     entservices-firmwareupdate \
+    entservices-userpreferences \
     entservices-mediaanddrm-screencapture \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \


### PR DESCRIPTION
Reason For Change: Integrate entservices-userpreferences to middleware builds
Test procedure : Compiled and Verified
Priority: P2
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]