### PR TITLE
RDKEMW-13091: Integrate powermanager plugin into MW builds

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -72,6 +72,7 @@ RDEPENDS:${PN} = " \
     entservices-softwareupdate \
     entservices-firmwaredownload \
     entservices-firmwareupdate \
+    entservices-powermanager \
     entservices-mediaanddrm-screencapture \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \


### PR DESCRIPTION
Reason For Change: Integrate powermanager into MW builds
Test procedure : Compiled and Verified
version: patch
Priority: P1