### PR TITLE
RDKEMW-12934: Integrate entservices-inputoutput repos to middleware build

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -64,7 +64,6 @@ RDEPENDS:${PN} = " \
     entservices-infra \
     entservices-rdkappmanagers \
     entservices-appgateway \
-    entservices-inputoutput \
     entservices-avinput \
     entservices-avoutput \
     entservices-mediaanddrm \

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -72,6 +72,9 @@ RDEPENDS:${PN} = " \
     entservices-softwareupdate \
     entservices-firmwaredownload \
     entservices-firmwareupdate \
+    entservices-hdmicecsource \
+    entservices-hdcpprofile \
+    entservices-avinput \
     entservices-mediaanddrm-screencapture \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -65,6 +65,7 @@ RDEPENDS:${PN} = " \
     entservices-rdkappmanagers \
     entservices-appgateway \
     entservices-inputoutput \
+    entservices-avinput \
     entservices-avoutput \
     entservices-mediaanddrm \
     entservices-peripherals \
@@ -72,9 +73,8 @@ RDEPENDS:${PN} = " \
     entservices-softwareupdate \
     entservices-firmwaredownload \
     entservices-firmwareupdate \
-    entservices-hdmicecsource \
     entservices-hdcpprofile \
-    entservices-avinput \
+    entservices-hdmicecsource \
     entservices-mediaanddrm-screencapture \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -73,8 +73,10 @@ RDEPENDS:${PN} = " \
     entservices-softwareupdate \
     entservices-firmwaredownload \
     entservices-firmwareupdate \
+    entservices-frontpanel \
     entservices-hdcpprofile \
     entservices-hdmicecsource \
+    entservices-hdmicecsink \
     entservices-mediaanddrm-screencapture \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \


### PR DESCRIPTION
Reason For Change: Integrated the entservices-inputoutput to middleware builds 
Test procedure : Compiled and Verified
Risks: Low
Priority: P2
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]