### PR TITLE
RDKEMW-13641:prelimnary middleware meta changes for player-interface component separation

### DIFF
--- a/conf/include/generic-middleware.inc
+++ b/conf/include/generic-middleware.inc
@@ -17,7 +17,7 @@ LAYER_NAME = "MIDDLEWARE"
 DISTRO_FEATURES:append = " enable_wpe-webdriver" 
 
 DISTRO_FEATURES:append = " RDKTV_APP_HIBERNATE"      
-DISTRO_FEATURES:remove = " netflix_cryptanium"           
+DISTRO_FEATURES:remove = " netflix_cryptanium"
 
 PARALLEL_MAKE:pn-breakpad = " -j2 "
 PARALLEL_MAKE:pn-breakpad-native = " -j2 "

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -52,6 +52,7 @@ RDEPENDS:${PN} = " \
     networkmanager-plugin \
     packagemanager \
     parodus \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'build_external_player_interface', "player-interface", "", d)} \
     rbus \
     rdk-logger \
     rdkat \


### PR DESCRIPTION
RDKEMW-13641:prelimnary middleware meta changes for player-interface component separation
Reason for change : merge meta changes ahead of middleware-player-interface component separation.
Test Steps : Basic AAMP regression on a platform from each SoC.
Signed-off by : R.Naren [naren_ramesh@comcast.com](mailto:naren_ramesh@comcast.com)