### PR TITLE
RDKEMW-12935: Migrate deviceanddisplay and inputoutput repo

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -74,6 +74,20 @@ RDEPENDS:${PN} = " \
     entservices-firmwareupdate \
     entservices-frontpanel \
     entservices-mediaanddrm-screencapture \
+    entservices-avinput \
+    entservices-devicediagnostics \
+    entservices-deviceinfo  \
+    entservices-displayinfo  \
+    entservices-displaysettings  \
+    entservices-framerate  \
+    entservices-hdcpprofile  \
+    entservices-hdmicecsink  \
+    entservices-hdmicecsource  \
+    entservices-powermanager  \
+    entservices-systemservices  \
+    entservices-systemmode  \
+    entservices-userpreferences  \
+    entservices-warehouse  \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \
     rdkversion \

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -60,11 +60,9 @@ RDEPENDS:${PN} = " \
     rdkperf \
     entservices-casting \
     entservices-connectivity \
-    entservices-deviceanddisplay \
     entservices-infra \
     entservices-rdkappmanagers \
     entservices-appgateway \
-    entservices-inputoutput \
     entservices-avoutput \
     entservices-mediaanddrm \
     entservices-peripherals \


### PR DESCRIPTION
Reason For Change: Migrate all plugins to it's own repo
Test procedure : Compiled and Verified
version: patch
Priority: P1