### PR TITLE
RDKEMW-13474: Integrate messagecontrol and monitor plugin into MW builds

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -74,6 +74,8 @@ RDEPENDS:${PN} = " \
     entservices-firmwareupdate \
     entservices-frontpanel \
     entservices-mediaanddrm-screencapture \
+    entservices-monitor \
+    entservices-messagecontrol \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \
     rdkversion \


### PR DESCRIPTION
Reason For Change: Integrate entservices-messagecontrol and monitor plugin to middleware builds
Test procedure : Compiled and Verified
version: patch
Priority: P1