### PR TITLE
RDKEMW-13479 : Integrate entservices-sharedstorage into middleware builds

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -74,6 +74,7 @@ RDEPENDS:${PN} = " \
     entservices-firmwareupdate \
     entservices-frontpanel \
     entservices-mediaanddrm-screencapture \
+    entservices-sharedstorage \
     ${@bb.utils.contains('DISTRO_FEATURES', 'DAC_SUPPORT', 'entservices-lisa', '', d)} \
     rdksysctl \
     rdkversion \


### PR DESCRIPTION
Reason For Change: Integrate entservices-sharedstorage to middleware builds
Test procedure : Compiled and Verified
version: patch
Priority: P2