### PR TITLE
RDKEMW-14726: Implement Chrony runtime selection for Time Sync

### DIFF
--- a/conf/include/generic-middleware.inc
+++ b/conf/include/generic-middleware.inc
@@ -26,4 +26,3 @@ PARALLEL_MAKE:pn-qtbase = " -j10 "
 BBMASK += "|poky/meta/recipes-multimedia/gstreamer"
 BBMASK += "|meta-openembedded/meta-multimedia/recipes-multimedia/gstreamer-1.0"
 BBMASK += "|meta-rdk/recipes-qt/qt5/qtwebsockets_5.1.1.bb"
-

--- a/conf/include/generic-middleware.inc
+++ b/conf/include/generic-middleware.inc
@@ -26,3 +26,8 @@ PARALLEL_MAKE:pn-qtbase = " -j10 "
 BBMASK += "|poky/meta/recipes-multimedia/gstreamer"
 BBMASK += "|meta-openembedded/meta-multimedia/recipes-multimedia/gstreamer-1.0"
 BBMASK += "|meta-rdk/recipes-qt/qt5/qtwebsockets_5.1.1.bb"
+
+
+STACK_LAYER_EXTENSION = "${MIDDLEWARE_ARCH}"
+IPK_FEED_URIS += "${STACK_LAYER_EXTENSION}##https://partners.artifactory.comcast.com/artifactory/middleware-dbg/chrony-8.4/xione-uk/ipks/debug"
+

--- a/conf/include/generic-middleware.inc
+++ b/conf/include/generic-middleware.inc
@@ -27,7 +27,3 @@ BBMASK += "|poky/meta/recipes-multimedia/gstreamer"
 BBMASK += "|meta-openembedded/meta-multimedia/recipes-multimedia/gstreamer-1.0"
 BBMASK += "|meta-rdk/recipes-qt/qt5/qtwebsockets_5.1.1.bb"
 
-
-STACK_LAYER_EXTENSION = "${MIDDLEWARE_ARCH}"
-IPK_FEED_URIS += "${STACK_LAYER_EXTENSION}##https://partners.artifactory.comcast.com/artifactory/middleware-dbg/chrony-8.4/xione-uk/ipks/debug"
-

--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -10,4 +10,8 @@ PV:pn-sqlite3see = "1.0.0"
 PR:pn-sqlite3see = "r0"
 PACKAGE_ARCH:pn-sqlite3see = "${MIDDLEWARE_ARCH}"
 
+PV:pn-chrony = "4.2"
+PR:pn-chrony = "r0"
+PACKAGE_ARCH:pn-chrony = "${MIDDLEWARE_ARCH}"
+
 PACKAGE_ARCH:pn-packagegroup-youtube-widgets = "${MIDDLEWARE_ARCH}"

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -192,6 +192,7 @@ RDEPENDS:${PN} = " \
     thunder-hang-recovery \
     thunder-plugin-activator \
     sqlite3 \
+    chrony \
     ${@bb.utils.contains('DISTRO_FEATURES', 'sceneset', " sceneset ", "", d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'enable_bolt_apps', '', 'aamp rdknativescript', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'enable_bolt_apps', '', 'wpe-webkit libwpe webkitbrowser-plugin', d)} \


### PR DESCRIPTION
Reason for change:
Implement runtime selection support for chronyd.
Integrate Chrony as part of the MW architecture and support build-time control based on distro configuration.

Test Procedure:
Validate the NTP client behavior for both systemd-timesyncd and chronyd based on the RFC configuration.

Risks: Low
Priority: P1
Signed-off-by: Sindhuja [Sindhuja_Muthukrishnan@comcast.com](mailto:Sindhuja_Muthukrishnan@comcast.com)