### PR TITLE
RDKEMW-12937: Reverting migration of new repo changes

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -75,17 +75,6 @@ RDEPENDS:${PN} = " \
     entservices-firmwareupdate \
     entservices-ledcontrol \
     entservices-frontpanel \
-    entservices-usersettings \
-    entservices-usbmassstorage \
-    entservices-usbdevice \
-    entservices-telemetry \
-    entservices-sharedstorage \
-    entservices-persistentstore \
-    entservices-ocicontainer \
-    entservices-monitor \
-    entservices-migration \
-    entservices-messagecontrol \
-    entservices-cloudstore \
     entservices-systemservices \
     entservices-deviceinfo \
     entservices-displayinfo \


### PR DESCRIPTION
Reason For Change: Reverting migration of new repo changes
Test procedure : Test ResourceManager
version : minor
Priority: P1