### PR TITLE
RDKEMW-12937: Reverting migration of new repo changes

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -86,7 +86,9 @@ RDEPENDS:${PN} = " \
     entservices-monitor \
     entservices-migration \
     entservices-messagecontrol \
-    entservices-cloudstore \
+    ${@bb.utils.contains_any('DISTRO_FEATURES', \
+    'RDKE_REGION_UK RDKE_REGION_IT RDKE_REGION_DE RDKE_REGION_AU RDKE_REGION_US', \
+    'entservices-cloudstore', '', d)} \
     entservices-systemservices \
     entservices-deviceinfo \
     entservices-displayinfo \

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -86,9 +86,7 @@ RDEPENDS:${PN} = " \
     entservices-monitor \
     entservices-migration \
     entservices-messagecontrol \
-    ${@bb.utils.contains_any('DISTRO_FEATURES', \
-    'RDKE_REGION_UK RDKE_REGION_IT RDKE_REGION_DE RDKE_REGION_AU RDKE_REGION_US', \
-    'entservices-cloudstore', '', d)} \
+    ${@bb.utils.contains_any('DISTRO_FEATURES','RDKE_REGION_UK RDKE_REGION_IT RDKE_REGION_DE RDKE_REGION_AU RDKE_REGION_US', 'entservices-cloudstore', '', d)} \
     entservices-systemservices \
     entservices-deviceinfo \
     entservices-displayinfo \

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -76,6 +76,17 @@ RDEPENDS:${PN} = " \
     entservices-firmwareupdate \
     entservices-ledcontrol \
     entservices-frontpanel \
+    entservices-usersettings \
+    entservices-usbmassstorage \
+    entservices-usbdevice \
+    entservices-telemetry \
+    entservices-sharedstorage \
+    entservices-persistentstore \
+    entservices-ocicontainer \
+    entservices-monitor \
+    entservices-migration \
+    entservices-messagecontrol \
+    entservices-cloudstore \
     entservices-systemservices \
     entservices-deviceinfo \
     entservices-displayinfo \


### PR DESCRIPTION
Reason For Change: Migration of new repo changes
Test procedure : compiled and verified
version : minor
Priority: P1