### PR TITLE
RDKEMW-14816 :  Move power-state-monitor to sys_mon_tools

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -43,6 +43,7 @@ RDEPENDS:${PN} = " \
     iarmbus \
     iarmmgrs \
     key-simulator \
+    power-state-monitor \
     libparodus \
     libsyswrapper \
     libunpriv \


### PR DESCRIPTION
Change-Id: I987391ae916d443ba363558a54f186be8bef2d9a