### PR TITLE
RDKEMW-15105: Networkmanager plugin release v1.12.4

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -283,7 +283,7 @@ PV:pn-memcr = "1.0.3"
 PR:pn-memcr = "r0"
 PACKAGE_ARCH:pn-memcr = "${MIDDLEWARE_ARCH}"
 
-PV:pn-networkmanager-plugin = "1.9.0"
+PV:pn-networkmanager-plugin = "1.12.4"
 PR:pn-networkmanager-plugin = "r0"
 PACKAGE_ARCH:pn-networkmanager-plugin = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for Change: Release of networkmanager v1.12.4 with the fix for ethernet connection issue during migration scenario
Test Procedure: Migration Scenario
Priority: P0
Risks: Medium