### PR TITLE
RDKEMW-15381: Removal of thunderHangRecovery (#2781)

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -202,7 +202,6 @@ RDEPENDS:${PN} = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'rdkwindowmanager', " rdkwindowmanager ", "", d)} \
     os-release \
     wlan-p2p \
-    thunder-hang-recovery \
     thunder-plugin-activator \
     sqlite3 \
     chrony \


### PR DESCRIPTION
Reason for change: Removing thunderHangRecovery
Test Procedure: Build and verified
Risks: Low
Priority: P1