### PR TITLE
RDKEMW-15910: bcm bb/bbappend analysis for sysint

### DIFF
--- a/recipes-core/images/middleware-test-image.bb
+++ b/recipes-core/images/middleware-test-image.bb
@@ -37,5 +37,18 @@ dobby_generic_config_patch(){
     fi
 }
 
+legacy_entos_support_patch(){
+    if [ -f "${IMAGE_ROOTFS}${sysconfdir}/common.properties" ]; then
+        rm -f ${IMAGE_ROOTFS}${sysconfdir}/common.properties
+    fi
+    if [ -f "${IMAGE_ROOTFS}/lib/rdk/imageFlasher.sh" ]; then
+        rm -f ${IMAGE_ROOTFS}/lib/rdk/imageFlasher.sh  
+    fi
+    if [ -f "${IMAGE_ROOTFS}/lib/rdk/init-zram.sh" ]; then
+        rm -f ${IMAGE_ROOTFS}/lib/rdk/init-zram.sh
+    fi
+}
+
 ROOTFS_POSTPROCESS_COMMAND += "wpeframework_binding_patch; "
 ROOTFS_POSTPROCESS_COMMAND += "dobby_generic_config_patch; "
+ROOTFS_POSTPROCESS_COMMAND += "legacy_entos_support_patch; "


### PR DESCRIPTION
Reason for change : avoid file conflicts by removing specific installed artifacts by sysint reciepe for tchxi6