### PR TITLE
RDKEMW-14189 - Increase thunder threads to 32 as an experiment

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -143,7 +143,7 @@ PV:pn-entservices-inputoutput = "1.4.7"
 PR:pn-entservices-inputoutput = "r0"
 PACKAGE_ARCH:pn-entservices-inputoutput = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-mediaanddrm = "1.3.6-hotfix.2"
+PV:pn-entservices-mediaanddrm = "1.3.6.3"
 PR:pn-entservices-mediaanddrm = "r0"
 PACKAGE_ARCH:pn-entservices-mediaanddrm = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Mitigate json rpc timeouts
Test Procedure: Reboot
Risks: Low
Priority: P1
version: patch