### PR TITLE
RDKEMW-18105 : [RDKM] rebootNow.sh script not found

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -114,6 +114,7 @@ RDEPENDS:${PN} = " \
     rdksysctl \
     rdkversion \
     rdmagent \
+    reboot-manager \
     rfc \
     rtcore \
     rtremote \


### PR DESCRIPTION
Updating Package group with reboot-manager