### PR TITLE
RDKEMW-18392: getFirmwareDownloadPercent api is failed During CDL Migration

### DIFF
--- a/conf/include/generic-pkgrev.inc
+++ b/conf/include/generic-pkgrev.inc
@@ -131,7 +131,7 @@ PV:pn-entservices-connectivity = "1.1.0"
 PR:pn-entservices-connectivity = "r0"
 PACKAGE_ARCH:pn-entservices-connectivity = "${MIDDLEWARE_ARCH}"
 
-PV:pn-entservices-deviceanddisplay = "3.1.19.2"
+PV:pn-entservices-deviceanddisplay = "3.1.19.3"
 PR:pn-entservices-deviceanddisplay = "r0"
 PACKAGE_ARCH:pn-entservices-deviceanddisplay = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: fixed the getFirmwareDownloadPercent api is failed During CDL Migration testing 
Test Procedure: Test getFirmwareDownloadPercent API 
Risks: Medium
Priority: P1
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]