### PR TITLE
RDKEMW-18580: Revert "RDKEMW-16976 : Integrate entservices-resourcemanager into middleware builds"

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -67,7 +67,6 @@ RDEPENDS:${PN} = " \
     entservices-miracast \
     entservices-connectivity \
     entservices-infra \
-    entservices-resourcemanager \
     entservices-rdkappmanagers \
     entservices-appgateway \
     entservices-avinput \


### PR DESCRIPTION
Reverts rdkcentral/meta-middleware-generic-support#2889