### PR TITLE
RDKEMW-19246 : Enable firmware-independent OTA Updates for MemInsight

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -51,7 +51,6 @@ RDEPENDS:${PN} = " \
     lsof \
     ${@bb.utils.contains('DISTRO_FEATURES', 'RDKTV_APP_HIBERNATE', "memcr ", "", d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'memcapture', 'memcapture', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'rdm', 'meminsight', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'enable_processmonitor_support', 'processmonitor', '', d)} \
     remotedebugger \
     networkmanager-plugin \


### PR DESCRIPTION
Reason for change: Remove meminsight dependencies from pacakgegroup
Test Procedure: Tested and verified
Risks: Low
Priority: P1
Signed-off-by: RoseMary_Benny@comcast.com