### PR TITLE
RDKEMW-20632: Removed entservice-ledcontol plugin from devices

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer-core-xfce.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer-core-xfce.bb
@@ -24,4 +24,5 @@ RDEPENDS:${PN} = " \
     telemetry \
     wpeframework \
     wpeframework-clientlibraries \
+    entservices-ledcontrol \
     "

--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -77,7 +77,6 @@ RDEPENDS:${PN} = " \
     entservices-maintenancemanager \
     entservices-firmwaredownload \
     entservices-firmwareupdate \
-    entservices-ledcontrol \
     entservices-frontpanel \
     entservices-remotecontrol \
     entservices-voicecontrol \


### PR DESCRIPTION
Removed entservice-ledcontol plugin from devices enabling only in vdevice