### PR TITLE
RDKEMW-18230: Create vdevice manifest with middleware compontents

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer-core-xfce.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer-core-xfce.bb
@@ -19,6 +19,7 @@ PR = "r0"
 #Generic components
 RDEPENDS:${PN} = " \
     entservices-hdmicecsource \
+    entservices-hdmicecsink \
     hdmicec \
     iarmbus \
     telemetry \


### PR DESCRIPTION
Reason for change: Create vdevice manifest with middleware compontents
Test Procedure: verify the builds are passed without any failures
Risks: Low
version: minor
Priority: P1

Signed-off-by:AkshayKumar_Gampa [AkshayKumar_Gampa@comcast.com](mailto:AkshayKumar_Gampa@comcast.com)