### PR TITLE
RDKEMW-20840:Integrate new releases to the vdevice middleware manifest

### DIFF
--- a/recipes-core/images/core-image-vdevice-xfce.bbappend
+++ b/recipes-core/images/core-image-vdevice-xfce.bbappend
@@ -1,3 +1,3 @@
 #Installing middleware packages into core image
 
-IMAGE_INSTALL:append = " packagegroup-middleware-layer-core-xfce "
+IMAGE_INSTALL:append = " packagegroup-middleware-layer-core-xfce python3 python3-core"


### PR DESCRIPTION
Reason for change: Integrating the latest releases to vdevice middleware manifest
Test Procedure: verify the builds are passed without any failures
Risks: Low
version: minor
Priority: P1
Signed-off-by:AkshayKumar_Gampa AkshayKumar_Gampa@comcast.com