### PR TITLE
RDKEMW-22307: Revert "RDKEMW-19574: App Managers 0.7.0.0 Release Integration"

### DIFF
--- a/recipes-core/packagegroups/packagegroup-middleware-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-middleware-layer.bb
@@ -164,7 +164,7 @@ RDEPENDS:${PN} = " \
     gdk-pixbuf \
     gupnp \
     iptables \
-    yaml-cpp \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'enable_rdkappmanagers_runtimeconfig', 'yaml-cpp', '', d)} \
     iw \
     wireless-tools \
     libcroco \


### PR DESCRIPTION
Reverts rdkcentral/meta-middleware-generic-support#3077